### PR TITLE
fix typo in README sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ w = EmptyGridWorld()
 
 w(MOVE_FORWARD)
 w(TURN_LEFT)
-w(RURN_RIGHT)
+w(TURN_RIGHT)
 
 # play interactively with Makie.
 # first time plot may be slow


### PR DESCRIPTION
Hi. I am fixing a small typo in the sample code in the README, so that directly copy-pasting the sample code runs smoothly in the REPL.